### PR TITLE
Add time.Time and *time.Time support to rulestone

### DIFF
--- a/TIME_SUPPORT_IMPLEMENTATION_PLAN.md
+++ b/TIME_SUPPORT_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,953 @@
+# Implementation Plan: time.Time Support for Rulestone
+
+## Executive Summary
+
+The rulestone library currently panics when processing events containing `time.Time` or `*time.Time` fields. While the library has `TimeOperand` infrastructure in place, there are two critical gaps:
+
+1. **Input Gap**: `NewInterfaceOperand()` doesn't recognize Go's `time.Time` or `*time.Time` types
+2. **Output Gap**: `MatchEvent()` doesn't handle `TimeOperand` (and other operand types) in category evaluation results
+
+## Root Cause Analysis
+
+### Problem 1: NewInterfaceOperand() Missing time.Time Handlers
+
+**Location**: `condition/condition.go:938-962`
+
+```go
+func NewInterfaceOperand(v interface{}, ctx *types.AppContext) Operand {
+    switch n := v.(type) {
+    case nil:
+        return NewNullOperand(nil)
+    case int:
+        return NewFloatOperand(float64(n))
+    case int64:
+        return NewFloatOperand(float64(n))
+    case string:
+        return NewStringOperand(n)
+    case float64:
+        return NewFloatOperand(n)
+    case bool:
+        return NewBooleanOperand(n)
+    case map[string]interface{}:
+        return NewErrorOperand(...)
+    case []interface{}:
+        return NewErrorOperand(...)
+    default:
+        panic("Should not get here")  // ← time.Time falls through here
+    }
+}
+```
+
+**Issue**: When a `time.Time` value is passed, it doesn't match any case and triggers the panic.
+
+### Problem 2: MatchEvent() Incomplete Operand Handling
+
+**Location**: `engine/engine_api.go:546-595`
+
+```go
+func (f *RuleEngine) MatchEvent(v interface{}) []condition.RuleIdType {
+    // ... event mapping and category evaluation ...
+
+    switch r := result.(type) {
+    case condition.ErrorOperand:
+        // Handle error
+    case condition.BooleanOperand:
+        // Handle boolean
+    case *condition.ListOperand:
+        // Handle list
+    case condition.IntOperand:
+        // Handle int
+    default:
+        panic("should not get here")  // ← Missing: StringOperand, FloatOperand, TimeOperand, NullOperand
+    }
+}
+```
+
+**Issue**: Category evaluation can return ANY operand type, but only 4 are handled. This affects not just `TimeOperand`, but also `StringOperand`, `FloatOperand`, and `NullOperand`.
+
+## Current TimeOperand Implementation Status
+
+### ✅ Already Implemented
+
+The codebase already has robust `TimeOperand` support:
+
+1. **Type Definition** (condition.go:508):
+   ```go
+   type TimeOperand time.Time
+   ```
+
+2. **Core Methods**:
+   - `NewTimeOperand(val time.Time) Operand`
+   - `GetKind() OperandKind` → Returns `TimeOperandKind = 5`
+   - `GetHash() uint64` → Uses `UnixNano()` for hashing
+   - `Equals(o SetElement) bool` → Uses `time.Time.Equal()`
+   - `Greater(o Operand) bool` → Uses `time.Time.After()`
+   - `Evaluate(...)` → Returns self
+   - `IsConst() bool` → Returns `true`
+
+3. **Conversion Methods** (condition.go:514-530):
+   - To `IntOperand`: Converts to Unix nanoseconds
+   - To `FloatOperand`: Converts to Unix nanoseconds as float64
+   - To `StringOperand`: Formats as RFC3339Nano
+   - To `TimeOperandKind`: Returns self
+   - To `NullOperandKind`: Returns null
+   - To `BooleanOperandKind`: Panics (intentionally unsupported)
+
+4. **Reverse Conversions** (from other types to TimeOperand):
+   - `IntOperand.Convert(TimeOperandKind)`: `time.Unix(0, int64(v))`
+   - `StringOperand.Convert(TimeOperandKind)`: Uses `dateparse.ParseAny()`
+   - `FloatOperand`: Similar to IntOperand
+
+### ❌ Missing Implementation
+
+1. No `time.Time` or `*time.Time` handling in `NewInterfaceOperand()`
+2. No `TimeOperand` handling in `MatchEvent()` result switch
+3. No tests for time values in events
+4. No documentation for time field usage
+
+## Implementation Plan
+
+### Phase 1: Core Fixes (Required for Basic Functionality)
+
+#### Fix 1.1: Add time.Time Support to NewInterfaceOperand()
+
+**File**: `condition/condition.go`
+**Location**: After line 948 (in `NewInterfaceOperand()` function)
+
+```go
+func NewInterfaceOperand(v interface{}, ctx *types.AppContext) Operand {
+    switch n := v.(type) {
+    case nil:
+        return NewNullOperand(nil)
+    case int:
+        return NewFloatOperand(float64(n))
+    case int64:
+        return NewFloatOperand(float64(n))
+    case string:
+        return NewStringOperand(n)
+    case float64:
+        return NewFloatOperand(n)
+    case bool:
+        return NewBooleanOperand(n)
+    // NEW: Handle time.Time values
+    case time.Time:
+        return NewTimeOperand(n)
+    // NEW: Handle *time.Time pointers
+    case *time.Time:
+        if n == nil {
+            return NewNullOperand(nil)
+        }
+        return NewTimeOperand(*n)
+    case map[string]interface{}:
+        return NewErrorOperand(...)
+    case []interface{}:
+        return NewErrorOperand(...)
+    default:
+        panic("Should not get here")
+    }
+}
+```
+
+**Key Decisions**:
+- `time.Time` values → `TimeOperand` directly
+- `*time.Time` pointers → Dereference if non-nil, `NullOperand` if nil
+- Maintains consistency with other type handling
+
+#### Fix 1.2: Complete MatchEvent() Operand Handling
+
+**File**: `engine/engine_api.go`
+**Location**: Around line 580-591
+
+```go
+// Current incomplete implementation:
+switch r := result.(type) {
+case condition.ErrorOperand:
+    // error handling
+case condition.BooleanOperand:
+    // boolean handling
+case *condition.ListOperand:
+    // list handling
+case condition.IntOperand:
+    // int handling
+default:
+    panic("should not get here")
+}
+
+// NEW: Complete implementation:
+switch r := result.(type) {
+case condition.ErrorOperand:
+    // Keep existing error handling
+
+case condition.BooleanOperand:
+    // Keep existing boolean handling
+    cat := catEvaluator.GetCategory()
+    if r {
+        eventCategories = append(eventCategories, cat)
+    }
+
+case *condition.ListOperand:
+    // Keep existing list handling
+    for _, c := range r.List {
+        cat := types.Category(c.(condition.IntOperand))
+        eventCategories = append(eventCategories, cat)
+    }
+
+case condition.IntOperand:
+    // Keep existing int handling
+    if r != 0 {
+        eventCategories = append(eventCategories, types.Category(r))
+    }
+
+// NEW CASES: Handle remaining operand types
+case condition.FloatOperand:
+    // Treat non-zero floats as truthy for category matching
+    if r != 0.0 {
+        cat := catEvaluator.GetCategory()
+        eventCategories = append(eventCategories, cat)
+    }
+
+case condition.StringOperand:
+    // Treat non-empty strings as truthy for category matching
+    if len(r) > 0 {
+        cat := catEvaluator.GetCategory()
+        eventCategories = append(eventCategories, cat)
+    }
+
+case condition.TimeOperand:
+    // Treat non-zero times as truthy for category matching
+    if !time.Time(r).IsZero() {
+        cat := catEvaluator.GetCategory()
+        eventCategories = append(eventCategories, cat)
+    }
+
+case condition.NullOperand:
+    // Null operands are falsy - don't add category
+    // (do nothing)
+
+default:
+    // This should now be unreachable for standard operand types
+    panic(fmt.Sprintf("Unexpected operand type in category evaluation: %T", result))
+}
+```
+
+**Design Rationale**:
+
+The new cases follow the "truthiness" pattern used by existing handlers:
+- `IntOperand`: Truthy if non-zero
+- `FloatOperand`: Truthy if non-zero (NEW)
+- `StringOperand`: Truthy if non-empty (NEW)
+- `TimeOperand`: Truthy if not zero time (NEW)
+- `BooleanOperand`: Truthy if true
+- `NullOperand`: Always falsy (NEW)
+
+This enables category expressions that evaluate to different types:
+```yaml
+# Boolean expression
+expression: total_accounts > 5
+
+# Numeric expression
+expression: risk_score * 2
+
+# String expression
+expression: user_name
+
+# Time expression
+expression: last_login_time
+```
+
+### Phase 2: Comprehensive Testing Strategy
+
+#### Test Suite 2.1: Unit Tests for NewInterfaceOperand()
+
+**File**: `condition/condition_test.go` (new or existing)
+
+```go
+func TestNewInterfaceOperand_TimeTypes(t *testing.T) {
+    ctx := types.NewAppContext()
+
+    t.Run("time.Time value", func(t *testing.T) {
+        now := time.Now()
+        op := NewInterfaceOperand(now, ctx)
+
+        require.Equal(t, TimeOperandKind, op.GetKind())
+        require.Equal(t, now, time.Time(op.(TimeOperand)))
+    })
+
+    t.Run("*time.Time non-nil pointer", func(t *testing.T) {
+        now := time.Now()
+        op := NewInterfaceOperand(&now, ctx)
+
+        require.Equal(t, TimeOperandKind, op.GetKind())
+        require.Equal(t, now, time.Time(op.(TimeOperand)))
+    })
+
+    t.Run("*time.Time nil pointer", func(t *testing.T) {
+        var nilTime *time.Time = nil
+        op := NewInterfaceOperand(nilTime, ctx)
+
+        require.Equal(t, NullOperandKind, op.GetKind())
+    })
+
+    t.Run("time.Time zero value", func(t *testing.T) {
+        var zeroTime time.Time
+        op := NewInterfaceOperand(zeroTime, ctx)
+
+        require.Equal(t, TimeOperandKind, op.GetKind())
+        require.True(t, time.Time(op.(TimeOperand)).IsZero())
+    })
+
+    t.Run("time.Time Unix epoch", func(t *testing.T) {
+        epoch := time.Unix(0, 0)
+        op := NewInterfaceOperand(epoch, ctx)
+
+        require.Equal(t, TimeOperandKind, op.GetKind())
+        require.Equal(t, epoch, time.Time(op.(TimeOperand)))
+    })
+
+    t.Run("time.Time with location", func(t *testing.T) {
+        loc, _ := time.LoadLocation("America/New_York")
+        now := time.Now().In(loc)
+        op := NewInterfaceOperand(now, ctx)
+
+        require.Equal(t, TimeOperandKind, op.GetKind())
+        require.True(t, now.Equal(time.Time(op.(TimeOperand))))
+    })
+}
+```
+
+**Coverage**: Type conversion, nil handling, edge cases, timezone awareness
+
+#### Test Suite 2.2: Integration Tests for MatchEvent()
+
+**File**: `engine/engine_test.go` or new test file
+
+```go
+func TestMatchEvent_TimeOperandCategories(t *testing.T) {
+    repo := engine.NewRuleEngineRepo()
+
+    // Rule that references a time field
+    yamlRule := `- metadata:
+    id: 1
+    name: Recent Login Check
+  expression: last_login != null
+`
+
+    result, err := repo.LoadRulesFromString(yamlRule,
+        engine.WithValidate(true),
+        engine.WithFileFormat("yaml"),
+    )
+    require.NoError(t, err)
+    require.True(t, result.ValidationOK)
+
+    ruleEngine, err := engine.NewRuleEngine(repo)
+    require.NoError(t, err)
+
+    t.Run("time.Time value triggers match", func(t *testing.T) {
+        event := map[string]interface{}{
+            "last_login": time.Now(),
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("*time.Time pointer triggers match", func(t *testing.T) {
+        now := time.Now()
+        event := map[string]interface{}{
+            "last_login": &now,
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("nil *time.Time does not match", func(t *testing.T) {
+        var nilTime *time.Time = nil
+        event := map[string]interface{}{
+            "last_login": nilTime,
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.NotContains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("zero time.Time triggers match", func(t *testing.T) {
+        // Zero time is still a valid time value, not null
+        var zeroTime time.Time
+        event := map[string]interface{}{
+            "last_login": zeroTime,
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+}
+```
+
+**Coverage**: Event matching with time fields, nil handling, zero time behavior
+
+#### Test Suite 2.3: Time Comparison Operations in Rules
+
+**File**: `engine/engine_time_comparison_test.go` (new)
+
+```go
+func TestRuleEngine_TimeComparisons(t *testing.T) {
+    repo := engine.NewRuleEngineRepo()
+
+    // Reference time: 2024-01-15 12:00:00 UTC
+    refTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+    before := refTime.Add(-1 * time.Hour)
+    after := refTime.Add(1 * time.Hour)
+
+    yamlRules := `
+- metadata:
+    id: 1
+    name: After Reference Time
+  expression: event_time > "2024-01-15T12:00:00Z"
+
+- metadata:
+    id: 2
+    name: Before Reference Time
+  expression: event_time < "2024-01-15T12:00:00Z"
+
+- metadata:
+    id: 3
+    name: Equal Reference Time
+  expression: event_time == "2024-01-15T12:00:00Z"
+
+- metadata:
+    id: 4
+    name: Recent Event (within 1 day)
+  expression: now() - event_time < 86400
+`
+
+    result, err := repo.LoadRulesFromString(yamlRules,
+        engine.WithValidate(true),
+        engine.WithFileFormat("yaml"),
+    )
+    require.NoError(t, err)
+    require.True(t, result.ValidationOK)
+
+    ruleEngine, err := engine.NewRuleEngine(repo)
+    require.NoError(t, err)
+
+    t.Run("time.Time after reference", func(t *testing.T) {
+        event := map[string]interface{}{
+            "event_time": after,
+        }
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+        require.NotContains(t, matchedIDs, condition.RuleIdType(2))
+        require.NotContains(t, matchedIDs, condition.RuleIdType(3))
+    })
+
+    t.Run("time.Time before reference", func(t *testing.T) {
+        event := map[string]interface{}{
+            "event_time": before,
+        }
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.NotContains(t, matchedIDs, condition.RuleIdType(1))
+        require.Contains(t, matchedIDs, condition.RuleIdType(2))
+        require.NotContains(t, matchedIDs, condition.RuleIdType(3))
+    })
+
+    t.Run("time.Time equal reference", func(t *testing.T) {
+        event := map[string]interface{}{
+            "event_time": refTime,
+        }
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.NotContains(t, matchedIDs, condition.RuleIdType(1))
+        require.NotContains(t, matchedIDs, condition.RuleIdType(2))
+        require.Contains(t, matchedIDs, condition.RuleIdType(3))
+    })
+
+    t.Run("*time.Time pointer comparisons", func(t *testing.T) {
+        afterPtr := after
+        event := map[string]interface{}{
+            "event_time": &afterPtr,
+        }
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+}
+
+func TestRuleEngine_TimezoneHandling(t *testing.T) {
+    repo := engine.NewRuleEngineRepo()
+
+    // Same instant in different timezones
+    utcTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+    estLoc, _ := time.LoadLocation("America/New_York")
+    estTime := utcTime.In(estLoc) // 07:00:00 EST
+
+    yamlRule := `- metadata:
+    id: 1
+    name: Same Instant Check
+  expression: event_time == "2024-01-15T12:00:00Z"
+`
+
+    result, err := repo.LoadRulesFromString(yamlRule,
+        engine.WithValidate(true),
+        engine.WithFileFormat("yaml"),
+    )
+    require.NoError(t, err)
+
+    ruleEngine, err := engine.NewRuleEngine(repo)
+    require.NoError(t, err)
+
+    t.Run("UTC time matches", func(t *testing.T) {
+        event := map[string]interface{}{"event_time": utcTime}
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("EST time matches same instant", func(t *testing.T) {
+        event := map[string]interface{}{"event_time": estTime}
+        matchedIDs := ruleEngine.MatchEvent(event)
+        // Should match because time.Time.Equal() compares instants
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+}
+```
+
+**Coverage**: Comparison operators, timezone handling, time arithmetic
+
+#### Test Suite 2.4: Time Conversion Between Operand Types
+
+**File**: `condition/condition_time_conversion_test.go` (new)
+
+```go
+func TestTimeOperand_Conversions(t *testing.T) {
+    refTime := time.Date(2024, 1, 15, 12, 30, 45, 123456789, time.UTC)
+    expectedNano := refTime.UnixNano()
+
+    t.Run("TimeOperand to IntOperand", func(t *testing.T) {
+        timeOp := NewTimeOperand(refTime)
+        intOp := timeOp.Convert(IntOperandKind)
+
+        require.Equal(t, IntOperandKind, intOp.GetKind())
+        require.Equal(t, IntOperand(expectedNano), intOp)
+    })
+
+    t.Run("TimeOperand to FloatOperand", func(t *testing.T) {
+        timeOp := NewTimeOperand(refTime)
+        floatOp := timeOp.Convert(FloatOperandKind)
+
+        require.Equal(t, FloatOperandKind, floatOp.GetKind())
+        require.Equal(t, FloatOperand(expectedNano), floatOp)
+    })
+
+    t.Run("TimeOperand to StringOperand", func(t *testing.T) {
+        timeOp := NewTimeOperand(refTime)
+        strOp := timeOp.Convert(StringOperandKind)
+
+        require.Equal(t, StringOperandKind, strOp.GetKind())
+        // Should be RFC3339Nano format
+        expectedStr := refTime.Format(time.RFC3339Nano)
+        require.Equal(t, StringOperand(expectedStr), strOp)
+    })
+
+    t.Run("IntOperand to TimeOperand (Unix nano)", func(t *testing.T) {
+        intOp := NewIntOperand(expectedNano)
+        timeOp := intOp.Convert(TimeOperandKind)
+
+        require.Equal(t, TimeOperandKind, timeOp.GetKind())
+        // Should reconstruct the time
+        reconstructed := time.Time(timeOp.(TimeOperand))
+        require.True(t, refTime.Equal(reconstructed))
+    })
+
+    t.Run("StringOperand to TimeOperand (RFC3339)", func(t *testing.T) {
+        strOp := NewStringOperand("2024-01-15T12:30:45Z")
+        timeOp := strOp.Convert(TimeOperandKind)
+
+        require.Equal(t, TimeOperandKind, timeOp.GetKind())
+        parsed := time.Time(timeOp.(TimeOperand))
+        expected := time.Date(2024, 1, 15, 12, 30, 45, 0, time.UTC)
+        require.True(t, expected.Equal(parsed))
+    })
+
+    t.Run("StringOperand to TimeOperand (various formats)", func(t *testing.T) {
+        testCases := []string{
+            "2024-01-15",
+            "2024-01-15T12:30:45Z",
+            "2024-01-15 12:30:45",
+            "Jan 15, 2024",
+            "01/15/2024",
+        }
+
+        for _, timeStr := range testCases {
+            t.Run(timeStr, func(t *testing.T) {
+                strOp := NewStringOperand(timeStr)
+                timeOp := strOp.Convert(TimeOperandKind)
+
+                // Should not be ErrorOperand
+                require.NotEqual(t, ErrorOperandKind, timeOp.GetKind())
+                require.Equal(t, TimeOperandKind, timeOp.GetKind())
+            })
+        }
+    })
+
+    t.Run("Invalid string to TimeOperand returns error", func(t *testing.T) {
+        strOp := NewStringOperand("not a date")
+        timeOp := strOp.Convert(TimeOperandKind)
+
+        require.Equal(t, ErrorOperandKind, timeOp.GetKind())
+    })
+}
+
+func TestTimeOperand_Comparison(t *testing.T) {
+    time1 := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+    time2 := time.Date(2024, 1, 16, 12, 0, 0, 0, time.UTC)
+
+    t.Run("Greater", func(t *testing.T) {
+        op1 := NewTimeOperand(time1)
+        op2 := NewTimeOperand(time2)
+
+        require.False(t, op1.Greater(op2))
+        require.True(t, op2.Greater(op1))
+    })
+
+    t.Run("Equals", func(t *testing.T) {
+        op1 := NewTimeOperand(time1)
+        op2 := NewTimeOperand(time1)
+        op3 := NewTimeOperand(time2)
+
+        require.True(t, op1.Equals(op2))
+        require.False(t, op1.Equals(op3))
+    })
+
+    t.Run("Equals with different timezones, same instant", func(t *testing.T) {
+        utcTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+        estLoc, _ := time.LoadLocation("America/New_York")
+        estTime := utcTime.In(estLoc)
+
+        op1 := NewTimeOperand(utcTime)
+        op2 := NewTimeOperand(estTime)
+
+        // Should be equal because they represent the same instant
+        require.True(t, op1.Equals(op2))
+    })
+}
+
+func TestTimeOperand_Hashing(t *testing.T) {
+    time1 := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+    time2 := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+    time3 := time.Date(2024, 1, 16, 12, 0, 0, 0, time.UTC)
+
+    op1 := NewTimeOperand(time1)
+    op2 := NewTimeOperand(time2)
+    op3 := NewTimeOperand(time3)
+
+    t.Run("Same times have same hash", func(t *testing.T) {
+        require.Equal(t, op1.GetHash(), op2.GetHash())
+    })
+
+    t.Run("Different times have different hash", func(t *testing.T) {
+        require.NotEqual(t, op1.GetHash(), op3.GetHash())
+    })
+}
+```
+
+**Coverage**: All conversion paths, comparison operations, hashing
+
+#### Test Suite 2.5: Edge Cases and Error Handling
+
+**File**: `engine/engine_time_edge_cases_test.go` (new)
+
+```go
+func TestMatchEvent_TimeEdgeCases(t *testing.T) {
+    repo := engine.NewRuleEngineRepo()
+
+    yamlRule := `- metadata:
+    id: 1
+    name: Time Field Check
+  expression: event_time != null
+`
+
+    result, err := repo.LoadRulesFromString(yamlRule,
+        engine.WithValidate(true),
+        engine.WithFileFormat("yaml"),
+    )
+    require.NoError(t, err)
+
+    ruleEngine, err := engine.NewRuleEngine(repo)
+    require.NoError(t, err)
+
+    t.Run("zero time.Time (default value)", func(t *testing.T) {
+        var zeroTime time.Time
+        event := map[string]interface{}{
+            "event_time": zeroTime,
+        }
+
+        // Zero time is a valid time, not null
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("nil *time.Time pointer", func(t *testing.T) {
+        var nilTime *time.Time = nil
+        event := map[string]interface{}{
+            "event_time": nilTime,
+        }
+
+        // Nil pointer should be treated as null
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.NotContains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("Unix epoch", func(t *testing.T) {
+        epoch := time.Unix(0, 0)
+        event := map[string]interface{}{
+            "event_time": epoch,
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("far future time", func(t *testing.T) {
+        farFuture := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+        event := map[string]interface{}{
+            "event_time": farFuture,
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("far past time", func(t *testing.T) {
+        farPast := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+        event := map[string]interface{}{
+            "event_time": farPast,
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("nanosecond precision", func(t *testing.T) {
+        nanoTime := time.Date(2024, 1, 15, 12, 0, 0, 123456789, time.UTC)
+        event := map[string]interface{}{
+            "event_time": nanoTime,
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+}
+
+func TestMatchEvent_TimeWithOtherTypes(t *testing.T) {
+    repo := engine.NewRuleEngineRepo()
+
+    // Mixed type event
+    yamlRule := `- metadata:
+    id: 1
+    name: Mixed Type Check
+  expression: user_count > 5 && last_login != null && is_active == true
+`
+
+    result, err := repo.LoadRulesFromString(yamlRule,
+        engine.WithValidate(true),
+        engine.WithFileFormat("yaml"),
+    )
+    require.NoError(t, err)
+
+    ruleEngine, err := engine.NewRuleEngine(repo)
+    require.NoError(t, err)
+
+    t.Run("mixed types including time.Time", func(t *testing.T) {
+        event := map[string]interface{}{
+            "user_count":  10,
+            "last_login":  time.Now(),
+            "is_active":   true,
+            "device_name": "iPhone 12",
+        }
+
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.Contains(t, matchedIDs, condition.RuleIdType(1))
+    })
+
+    t.Run("mixed types with nil *time.Time", func(t *testing.T) {
+        var nilTime *time.Time = nil
+        event := map[string]interface{}{
+            "user_count": 10,
+            "last_login": nilTime,
+            "is_active":  true,
+        }
+
+        // Should not match because last_login is null
+        matchedIDs := ruleEngine.MatchEvent(event)
+        require.NotContains(t, matchedIDs, condition.RuleIdType(1))
+    })
+}
+```
+
+**Coverage**: Edge cases, boundary conditions, mixed type events
+
+### Phase 3: Documentation and Examples
+
+#### Doc 3.1: Update README or docs with time.Time usage
+
+**Example documentation to add**:
+
+```markdown
+## Using Time Fields in Events
+
+Rulestone supports `time.Time` and `*time.Time` fields in events. Time values can be compared against string literals or other time expressions.
+
+### Supported Time Types
+
+- `time.Time`: Go time values
+- `*time.Time`: Pointers to time values (nil treated as null)
+
+### Time Comparison Examples
+
+```go
+// Event with time fields
+event := map[string]interface{}{
+    "last_login": time.Now(),
+    "account_created": time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+}
+
+// Rules can compare times
+rules := `
+- metadata:
+    id: 1
+    name: Recent Login
+  expression: last_login > "2024-01-01T00:00:00Z"
+
+- metadata:
+    id: 2
+    name: Old Account
+  expression: account_created < "2023-01-01T00:00:00Z"
+`
+```
+
+### Time Conversions
+
+Time values are automatically converted when compared with other types:
+- To `int`/`float`: Unix nanoseconds
+- To `string`: RFC3339Nano format
+- From `string`: Parsed using flexible date parser
+
+### Nil Handling
+
+`*time.Time` nil pointers are treated as `null`:
+
+```go
+var nilTime *time.Time = nil
+event := map[string]interface{}{
+    "last_login": nilTime,  // Treated as null
+}
+
+// Check for null
+expression: last_login == null  // Matches
+```
+```
+
+#### Doc 3.2: Add examples to tests or example files
+
+Create `examples/time_usage_example.go` demonstrating common patterns.
+
+## Testing Matrix
+
+| Test Category | File | Test Count | Priority |
+|--------------|------|------------|----------|
+| Unit - Type Conversion | `condition/condition_test.go` | 6 | High |
+| Unit - Time Conversion | `condition/condition_time_conversion_test.go` | 10 | High |
+| Integration - MatchEvent | `engine/engine_test.go` | 4 | High |
+| Integration - Comparisons | `engine/engine_time_comparison_test.go` | 6 | High |
+| Edge Cases | `engine/engine_time_edge_cases_test.go` | 11 | Medium |
+| User-provided Test | Existing test file | 5 | High |
+
+**Total**: ~42 new tests + user's 5 tests = **47 tests**
+
+## Implementation Checklist
+
+- [ ] Fix 1.1: Add time.Time handling to NewInterfaceOperand()
+- [ ] Fix 1.2: Add TimeOperand case to MatchEvent() switch
+- [ ] Fix 1.3: Add FloatOperand case to MatchEvent() switch
+- [ ] Fix 1.4: Add StringOperand case to MatchEvent() switch
+- [ ] Fix 1.5: Add NullOperand case to MatchEvent() switch
+- [ ] Test 2.1: Unit tests for NewInterfaceOperand() time handling
+- [ ] Test 2.2: Integration tests for MatchEvent() with time fields
+- [ ] Test 2.3: Time comparison operation tests
+- [ ] Test 2.4: Time conversion tests
+- [ ] Test 2.5: Edge case tests
+- [ ] Test 2.6: Verify user's reproduction test passes
+- [ ] Doc 3.1: Update documentation
+- [ ] Doc 3.2: Add usage examples
+
+## Risk Assessment
+
+### Low Risk
+- Adding time.Time cases to NewInterfaceOperand() - additive change
+- TimeOperand already exists and is well-tested
+
+### Medium Risk
+- MatchEvent() switch statement expansion - affects core matching logic
+- Need to ensure "truthiness" semantics are consistent
+
+### Mitigation
+- Comprehensive test coverage before and after changes
+- Run full existing test suite to catch regressions
+- Review coverage reports
+
+## Performance Considerations
+
+- Time conversion via `UnixNano()` is O(1)
+- Time comparison via `time.Time.Equal()` and `After()` is O(1)
+- No allocation overhead for TimeOperand (value type wrapping time.Time)
+- String parsing via `dateparse.ParseAny()` is more expensive but only happens during conversion
+
+## Alternative Approaches Considered
+
+### Alternative 1: Convert time.Time to float64 immediately
+```go
+case time.Time:
+    return NewFloatOperand(float64(n.UnixNano()))
+```
+
+**Pros**: No changes needed to MatchEvent()
+**Cons**: Loses time semantics, makes time comparisons harder in rules
+
+**Decision**: Rejected - Keep TimeOperand for semantic clarity
+
+### Alternative 2: Add custom time comparison functions
+```go
+expression: time_after(last_login, "2024-01-01")
+```
+
+**Pros**: Explicit time operations
+**Cons**: Verbose, not idiomatic for rule expressions
+
+**Decision**: Rejected - Use natural comparison operators
+
+## Success Criteria
+
+1. ✅ User's test case passes without panic
+2. ✅ All 47+ tests pass
+3. ✅ No regressions in existing test suite
+4. ✅ Code coverage maintained or improved
+5. ✅ Documentation updated with time usage examples
+
+## Future Enhancements (Out of Scope)
+
+- Time arithmetic functions: `add_days()`, `add_hours()`, etc.
+- Duration type support
+- Time formatting functions
+- Relative time expressions: `now() - 1d`
+
+## Questions for Review
+
+1. Should zero time.Time be treated as null or as a valid time value?
+   - **Decision**: Valid time value (not null)
+   - **Rationale**: Consistent with Go semantics; zero time ≠ nil pointer
+
+2. Should MatchEvent() panic or return error for unexpected operand types?
+   - **Decision**: Keep panic with improved error message
+   - **Rationale**: Indicates programming error, should fail fast
+
+3. Should FloatOperand/StringOperand be "truthy" for category matching?
+   - **Decision**: Yes, non-zero/non-empty are truthy
+   - **Rationale**: Consistent with existing IntOperand behavior

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -952,6 +952,13 @@ func NewInterfaceOperand(v interface{}, ctx *types.AppContext) Operand {
 		return NewFloatOperand(n)
 	case bool:
 		return NewBooleanOperand(n)
+	case time.Time:
+		return NewTimeOperand(n)
+	case *time.Time:
+		if n == nil {
+			return NewNullOperand(nil)
+		}
+		return NewTimeOperand(*n)
 	case map[string]interface{}:
 		return NewErrorOperand(ctx.Errorf("scalar operand expected got map: %v", v))
 	case []interface{}:

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184
 	github.com/dchest/siphash v1.2.3
+	github.com/stretchr/testify v1.7.0
 	github.com/zyedidia/generic v1.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 )

--- a/tests/condition_test.go
+++ b/tests/condition_test.go
@@ -2,7 +2,11 @@ package tests_test
 
 import (
 	"fmt"
+	"time"
+
 	c "github.com/atlasgurus/rulestone/condition"
+	"github.com/atlasgurus/rulestone/types"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -25,5 +29,59 @@ func TestOf(t *testing.T) {
 			))
 
 		fmt.Println(rule)
+	})
+}
+
+// TestNewInterfaceOperand_TimeTypes tests time.Time and *time.Time handling in NewInterfaceOperand
+func TestNewInterfaceOperand_TimeTypes(t *testing.T) {
+	ctx := types.NewAppContext()
+
+	t.Run("time.Time value", func(t *testing.T) {
+		now := time.Now()
+		op := c.NewInterfaceOperand(now, ctx)
+
+		require.EqualValues(t, c.TimeOperandKind, op.GetKind())
+		require.True(t, now.Equal(time.Time(op.(c.TimeOperand))))
+	})
+
+	t.Run("*time.Time non-nil pointer", func(t *testing.T) {
+		now := time.Now()
+		op := c.NewInterfaceOperand(&now, ctx)
+
+		require.EqualValues(t, c.TimeOperandKind, op.GetKind())
+		require.True(t, now.Equal(time.Time(op.(c.TimeOperand))))
+	})
+
+	t.Run("*time.Time nil pointer", func(t *testing.T) {
+		var nilTime *time.Time = nil
+		op := c.NewInterfaceOperand(nilTime, ctx)
+
+		require.EqualValues(t, c.NullOperandKind, op.GetKind())
+	})
+
+	t.Run("time.Time zero value", func(t *testing.T) {
+		var zeroTime time.Time
+		op := c.NewInterfaceOperand(zeroTime, ctx)
+
+		require.EqualValues(t, c.TimeOperandKind, op.GetKind())
+		require.True(t, time.Time(op.(c.TimeOperand)).IsZero())
+	})
+
+	t.Run("time.Time Unix epoch", func(t *testing.T) {
+		epoch := time.Unix(0, 0)
+		op := c.NewInterfaceOperand(epoch, ctx)
+
+		require.EqualValues(t, c.TimeOperandKind, op.GetKind())
+		require.True(t, epoch.Equal(time.Time(op.(c.TimeOperand))))
+	})
+
+	t.Run("time.Time with location", func(t *testing.T) {
+		loc, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		now := time.Now().In(loc)
+		op := c.NewInterfaceOperand(now, ctx)
+
+		require.EqualValues(t, c.TimeOperandKind, op.GetKind())
+		require.True(t, now.Equal(time.Time(op.(c.TimeOperand))))
 	})
 }

--- a/tests/condition_time_conversion_test.go
+++ b/tests/condition_time_conversion_test.go
@@ -1,0 +1,201 @@
+package tests_test
+
+import (
+	"testing"
+	"time"
+
+	c "github.com/atlasgurus/rulestone/condition"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTimeOperand_Conversions tests all conversion paths for TimeOperand
+func TestTimeOperand_Conversions(t *testing.T) {
+	refTime := time.Date(2024, 1, 15, 12, 30, 45, 123456789, time.UTC)
+	expectedNano := refTime.UnixNano()
+
+	t.Run("TimeOperand to IntOperand", func(t *testing.T) {
+		timeOp := c.NewTimeOperand(refTime)
+		intOp := timeOp.Convert(c.IntOperandKind)
+
+		require.EqualValues(t, c.IntOperandKind, intOp.GetKind())
+		require.Equal(t, c.IntOperand(expectedNano), intOp)
+	})
+
+	t.Run("TimeOperand to FloatOperand", func(t *testing.T) {
+		timeOp := c.NewTimeOperand(refTime)
+		floatOp := timeOp.Convert(c.FloatOperandKind)
+
+		require.EqualValues(t, c.FloatOperandKind, floatOp.GetKind())
+		require.Equal(t, c.FloatOperand(expectedNano), floatOp)
+	})
+
+	t.Run("TimeOperand to StringOperand", func(t *testing.T) {
+		timeOp := c.NewTimeOperand(refTime)
+		strOp := timeOp.Convert(c.StringOperandKind)
+
+		require.EqualValues(t, c.StringOperandKind, strOp.GetKind())
+		// Should be RFC3339Nano format
+		expectedStr := refTime.Format(time.RFC3339Nano)
+		require.Equal(t, c.StringOperand(expectedStr), strOp)
+	})
+
+	t.Run("IntOperand to TimeOperand (Unix nano)", func(t *testing.T) {
+		intOp := c.NewIntOperand(expectedNano)
+		timeOp := intOp.Convert(c.TimeOperandKind)
+
+		require.EqualValues(t, c.TimeOperandKind, timeOp.GetKind())
+		// Should reconstruct the time
+		reconstructed := time.Time(timeOp.(c.TimeOperand))
+		require.True(t, refTime.Equal(reconstructed))
+	})
+
+	t.Run("StringOperand to TimeOperand (RFC3339)", func(t *testing.T) {
+		strOp := c.NewStringOperand("2024-01-15T12:30:45Z")
+		timeOp := strOp.Convert(c.TimeOperandKind)
+
+		require.EqualValues(t, c.TimeOperandKind, timeOp.GetKind())
+		parsed := time.Time(timeOp.(c.TimeOperand))
+		expected := time.Date(2024, 1, 15, 12, 30, 45, 0, time.UTC)
+		require.True(t, expected.Equal(parsed))
+	})
+
+	t.Run("StringOperand to TimeOperand (various formats)", func(t *testing.T) {
+		testCases := []string{
+			"2024-01-15",
+			"2024-01-15T12:30:45Z",
+			"2024-01-15 12:30:45",
+			"Jan 15, 2024",
+			"01/15/2024",
+		}
+
+		for _, timeStr := range testCases {
+			t.Run(timeStr, func(t *testing.T) {
+				strOp := c.NewStringOperand(timeStr)
+				timeOp := strOp.Convert(c.TimeOperandKind)
+
+				// Should not be ErrorOperand
+				require.NotEqualValues(t, c.ErrorOperandKind, timeOp.GetKind())
+				require.EqualValues(t, c.TimeOperandKind, timeOp.GetKind())
+			})
+		}
+	})
+
+	t.Run("Invalid string to TimeOperand returns error", func(t *testing.T) {
+		strOp := c.NewStringOperand("not a date")
+		timeOp := strOp.Convert(c.TimeOperandKind)
+
+		require.EqualValues(t, c.ErrorOperandKind, timeOp.GetKind())
+	})
+
+	t.Run("FloatOperand to TimeOperand (Unix nano)", func(t *testing.T) {
+		floatOp := c.NewFloatOperand(float64(expectedNano))
+		timeOp := floatOp.Convert(c.TimeOperandKind)
+
+		require.EqualValues(t, c.TimeOperandKind, timeOp.GetKind())
+		reconstructed := time.Time(timeOp.(c.TimeOperand))
+		// Note: float64 can lose precision for large integers like Unix nanoseconds
+		// so we check that the times are within a reasonable delta (1 microsecond)
+		diff := refTime.Sub(reconstructed)
+		if diff < 0 {
+			diff = -diff
+		}
+		require.True(t, diff < time.Microsecond, "Time difference %v should be less than 1 microsecond", diff)
+	})
+
+	t.Run("TimeOperand to NullOperand", func(t *testing.T) {
+		timeOp := c.NewTimeOperand(refTime)
+		nullOp := timeOp.Convert(c.NullOperandKind)
+
+		require.EqualValues(t, c.NullOperandKind, nullOp.GetKind())
+	})
+
+	t.Run("TimeOperand to TimeOperand (identity)", func(t *testing.T) {
+		timeOp := c.NewTimeOperand(refTime)
+		timeOp2 := timeOp.Convert(c.TimeOperandKind)
+
+		require.EqualValues(t, c.TimeOperandKind, timeOp2.GetKind())
+		require.True(t, refTime.Equal(time.Time(timeOp2.(c.TimeOperand))))
+	})
+}
+
+// TestTimeOperand_Comparison tests TimeOperand comparison operations
+func TestTimeOperand_Comparison(t *testing.T) {
+	time1 := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	time2 := time.Date(2024, 1, 16, 12, 0, 0, 0, time.UTC)
+
+	t.Run("Greater", func(t *testing.T) {
+		op1 := c.NewTimeOperand(time1)
+		op2 := c.NewTimeOperand(time2)
+
+		require.False(t, op1.Greater(op2))
+		require.True(t, op2.Greater(op1))
+	})
+
+	t.Run("Equals", func(t *testing.T) {
+		op1 := c.NewTimeOperand(time1)
+		op2 := c.NewTimeOperand(time1)
+		op3 := c.NewTimeOperand(time2)
+
+		require.True(t, op1.Equals(op2))
+		require.False(t, op1.Equals(op3))
+	})
+
+	t.Run("Equals with different timezones, same instant", func(t *testing.T) {
+		utcTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+		estLoc, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		estTime := utcTime.In(estLoc)
+
+		op1 := c.NewTimeOperand(utcTime)
+		op2 := c.NewTimeOperand(estTime)
+
+		// Should be equal because they represent the same instant
+		require.True(t, op1.Equals(op2))
+	})
+
+	t.Run("Greater with different timezones", func(t *testing.T) {
+		utcTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+		estLoc, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		laterTime := utcTime.Add(1 * time.Hour)
+		estTime := laterTime.In(estLoc)
+
+		op1 := c.NewTimeOperand(utcTime)
+		op2 := c.NewTimeOperand(estTime)
+
+		require.True(t, op2.Greater(op1))
+		require.False(t, op1.Greater(op2))
+	})
+}
+
+// TestTimeOperand_Hashing tests TimeOperand hash generation
+func TestTimeOperand_Hashing(t *testing.T) {
+	time1 := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	time2 := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	time3 := time.Date(2024, 1, 16, 12, 0, 0, 0, time.UTC)
+
+	op1 := c.NewTimeOperand(time1)
+	op2 := c.NewTimeOperand(time2)
+	op3 := c.NewTimeOperand(time3)
+
+	t.Run("Same times have same hash", func(t *testing.T) {
+		require.Equal(t, op1.GetHash(), op2.GetHash())
+	})
+
+	t.Run("Different times have different hash", func(t *testing.T) {
+		require.NotEqual(t, op1.GetHash(), op3.GetHash())
+	})
+
+	t.Run("Same instant in different timezones have same hash", func(t *testing.T) {
+		utcTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+		estLoc, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		estTime := utcTime.In(estLoc)
+
+		opUTC := c.NewTimeOperand(utcTime)
+		opEST := c.NewTimeOperand(estTime)
+
+		// Same instant should have same hash
+		require.Equal(t, opUTC.GetHash(), opEST.GetHash())
+	})
+}

--- a/tests/engine_time_comparison_test.go
+++ b/tests/engine_time_comparison_test.go
@@ -1,0 +1,225 @@
+package tests_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atlasgurus/rulestone/condition"
+	"github.com/atlasgurus/rulestone/engine"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRuleEngine_TimeComparisons tests time comparison operations in rules
+func TestRuleEngine_TimeComparisons(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	// Reference time: 2024-01-15 12:00:00 UTC
+	refTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	before := refTime.Add(-1 * time.Hour)
+	after := refTime.Add(1 * time.Hour)
+
+	yamlRules := `
+- metadata:
+    id: 1
+    name: After Reference Time
+  expression: event_time > "2024-01-15T12:00:00Z"
+
+- metadata:
+    id: 2
+    name: Before Reference Time
+  expression: event_time < "2024-01-15T12:00:00Z"
+
+- metadata:
+    id: 3
+    name: Equal Reference Time
+  expression: event_time == "2024-01-15T12:00:00Z"
+
+- metadata:
+    id: 4
+    name: Not Equal Reference Time
+  expression: event_time != "2024-01-15T12:00:00Z"
+`
+
+	result, err := repo.LoadRulesFromString(yamlRules,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("time.Time after reference", func(t *testing.T) {
+		event := map[string]interface{}{
+			"event_time": after,
+		}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+		require.NotContains(t, matchedIDs, condition.RuleIdType(1))
+		require.NotContains(t, matchedIDs, condition.RuleIdType(2))
+		require.Contains(t, matchedIDs, condition.RuleIdType(3))
+	})
+
+	t.Run("time.Time before reference", func(t *testing.T) {
+		event := map[string]interface{}{
+			"event_time": before,
+		}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+		require.Contains(t, matchedIDs, condition.RuleIdType(1))
+		require.NotContains(t, matchedIDs, condition.RuleIdType(2))
+		require.Contains(t, matchedIDs, condition.RuleIdType(3))
+	})
+
+	t.Run("time.Time equal reference", func(t *testing.T) {
+		event := map[string]interface{}{
+			"event_time": refTime,
+		}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+		require.NotContains(t, matchedIDs, condition.RuleIdType(1))
+		require.Contains(t, matchedIDs, condition.RuleIdType(2))
+		require.NotContains(t, matchedIDs, condition.RuleIdType(3))
+	})
+
+	t.Run("*time.Time pointer comparisons", func(t *testing.T) {
+		afterPtr := after
+		event := map[string]interface{}{
+			"event_time": &afterPtr,
+		}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("time.Time with nanosecond precision", func(t *testing.T) {
+		// Time with nanoseconds
+		nanoTime := time.Date(2024, 1, 15, 12, 0, 0, 123456789, time.UTC)
+		event := map[string]interface{}{
+			"event_time": nanoTime,
+		}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		// Should still be after refTime (which has 0 nanoseconds)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("time.Time greater than or equal", func(t *testing.T) {
+		repo2 := engine.NewRuleEngineRepo()
+		yamlRule := `- metadata:
+    id: 1
+    name: Greater or Equal
+  expression: event_time >= "2024-01-15T12:00:00Z"
+`
+		result, err := repo2.LoadRulesFromString(yamlRule,
+			engine.WithValidate(true),
+			engine.WithFileFormat("yaml"),
+		)
+		require.NoError(t, err)
+		require.True(t, result.ValidationOK)
+
+		ruleEngine2, err := engine.NewRuleEngine(repo2)
+		require.NoError(t, err)
+
+		// Test equal time
+		event1 := map[string]interface{}{"event_time": refTime}
+		matchedIDs1 := ruleEngine2.MatchEvent(event1)
+		require.Contains(t, matchedIDs1, condition.RuleIdType(0))
+
+		// Test greater time
+		event2 := map[string]interface{}{"event_time": after}
+		matchedIDs2 := ruleEngine2.MatchEvent(event2)
+		require.Contains(t, matchedIDs2, condition.RuleIdType(0))
+
+		// Test lesser time
+		event3 := map[string]interface{}{"event_time": before}
+		matchedIDs3 := ruleEngine2.MatchEvent(event3)
+		require.NotContains(t, matchedIDs3, condition.RuleIdType(0))
+	})
+}
+
+// TestRuleEngine_TimezoneHandling tests timezone-aware time comparisons
+func TestRuleEngine_TimezoneHandling(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	// Same instant in different timezones
+	utcTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	estLoc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	estTime := utcTime.In(estLoc) // 07:00:00 EST (same instant)
+
+	yamlRule := `- metadata:
+    id: 1
+    name: Same Instant Check
+  expression: event_time == "2024-01-15T12:00:00Z"
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("UTC time matches", func(t *testing.T) {
+		event := map[string]interface{}{"event_time": utcTime}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("EST time matches same instant", func(t *testing.T) {
+		event := map[string]interface{}{"event_time": estTime}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		// Should match because time.Time.Equal() compares instants
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("Different instant in EST does not match", func(t *testing.T) {
+		// Different instant: 2024-01-15 12:00:00 EST (which is 17:00:00 UTC)
+		differentEstTime := time.Date(2024, 1, 15, 12, 0, 0, 0, estLoc)
+		event := map[string]interface{}{"event_time": differentEstTime}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}
+
+// TestRuleEngine_TimeArithmetic tests time arithmetic in rules
+func TestRuleEngine_TimeArithmetic(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	yamlRule := `- metadata:
+    id: 1
+    name: Recent Event (within 1 day in seconds)
+  expression: (now() - event_time) < 86400000000000
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("recent time matches", func(t *testing.T) {
+		recentTime := time.Now().Add(-1 * time.Hour)
+		event := map[string]interface{}{
+			"event_time": recentTime,
+		}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("old time does not match", func(t *testing.T) {
+		oldTime := time.Now().Add(-2 * 24 * time.Hour) // 2 days ago
+		event := map[string]interface{}{
+			"event_time": oldTime,
+		}
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}

--- a/tests/engine_time_edge_cases_test.go
+++ b/tests/engine_time_edge_cases_test.go
@@ -1,0 +1,270 @@
+package tests_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atlasgurus/rulestone/condition"
+	"github.com/atlasgurus/rulestone/engine"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMatchEvent_TimeEdgeCases tests edge cases for time.Time handling
+func TestMatchEvent_TimeEdgeCases(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	yamlRule := `- metadata:
+    id: 1
+    name: Time Field Check
+  expression: event_time != null
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("zero time.Time (default value)", func(t *testing.T) {
+		var zeroTime time.Time
+		event := map[string]interface{}{
+			"event_time": zeroTime,
+		}
+
+		// Zero time is a valid time, not null
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("nil *time.Time pointer", func(t *testing.T) {
+		var nilTime *time.Time = nil
+		event := map[string]interface{}{
+			"event_time": nilTime,
+		}
+
+		// Nil pointer should be treated as null
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("Unix epoch", func(t *testing.T) {
+		epoch := time.Unix(0, 0)
+		event := map[string]interface{}{
+			"event_time": epoch,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("far future time", func(t *testing.T) {
+		farFuture := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+		event := map[string]interface{}{
+			"event_time": farFuture,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("far past time", func(t *testing.T) {
+		farPast := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+		event := map[string]interface{}{
+			"event_time": farPast,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("nanosecond precision", func(t *testing.T) {
+		nanoTime := time.Date(2024, 1, 15, 12, 0, 0, 123456789, time.UTC)
+		event := map[string]interface{}{
+			"event_time": nanoTime,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("time at exact midnight", func(t *testing.T) {
+		midnight := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+		event := map[string]interface{}{
+			"event_time": midnight,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("time at exact noon", func(t *testing.T) {
+		noon := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+		event := map[string]interface{}{
+			"event_time": noon,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("leap second boundary", func(t *testing.T) {
+		// Test time near leap second boundary
+		leapTime := time.Date(2016, 12, 31, 23, 59, 59, 999999999, time.UTC)
+		event := map[string]interface{}{
+			"event_time": leapTime,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("february 29 leap year", func(t *testing.T) {
+		leapDay := time.Date(2024, 2, 29, 12, 0, 0, 0, time.UTC)
+		event := map[string]interface{}{
+			"event_time": leapDay,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("daylight saving time transition", func(t *testing.T) {
+		// DST transition time in US (Spring forward: 2024-03-10 02:00:00 EST -> 03:00:00 EDT)
+		loc, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		dstTime := time.Date(2024, 3, 10, 2, 30, 0, 0, loc)
+		event := map[string]interface{}{
+			"event_time": dstTime,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}
+
+// TestMatchEvent_TimeIsZeroCheck tests time.IsZero() behavior with comparisons
+func TestMatchEvent_TimeIsZeroCheck(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	// Test that zero time behaves correctly in comparisons
+	yamlRule := `- metadata:
+    id: 1
+    name: Non-null time check
+  expression: event_time != null
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("non-zero time matches", func(t *testing.T) {
+		now := time.Now()
+		event := map[string]interface{}{
+			"event_time": now,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("zero time matches (zero time is not null)", func(t *testing.T) {
+		var zeroTime time.Time
+		event := map[string]interface{}{
+			"event_time": zeroTime,
+		}
+
+		// Zero time is a valid time value, not null
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("nil *time.Time does not match", func(t *testing.T) {
+		var nilTime *time.Time = nil
+		event := map[string]interface{}{
+			"event_time": nilTime,
+		}
+
+		// Nil pointer is treated as null
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("Unix epoch matches", func(t *testing.T) {
+		epoch := time.Unix(0, 0)
+		event := map[string]interface{}{
+			"event_time": epoch,
+		}
+
+		// Unix epoch is a valid time, not null
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}
+
+// TestMatchEvent_MultipleTimeFields tests events with multiple time fields
+func TestMatchEvent_MultipleTimeFields(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	yamlRule := `- metadata:
+    id: 1
+    name: Multiple Time Fields
+  expression: created_at < updated_at && updated_at < accessed_at
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("ordered time fields match", func(t *testing.T) {
+		now := time.Now()
+		event := map[string]interface{}{
+			"created_at":  now.Add(-2 * time.Hour),
+			"updated_at":  now.Add(-1 * time.Hour),
+			"accessed_at": now,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("unordered time fields do not match", func(t *testing.T) {
+		now := time.Now()
+		event := map[string]interface{}{
+			"created_at":  now,
+			"updated_at":  now.Add(-1 * time.Hour),
+			"accessed_at": now.Add(-2 * time.Hour),
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("mixed time.Time and *time.Time", func(t *testing.T) {
+		now := time.Now()
+		updated := now.Add(-1 * time.Hour)
+		event := map[string]interface{}{
+			"created_at":  now.Add(-2 * time.Hour), // time.Time
+			"updated_at":  &updated,                 // *time.Time
+			"accessed_at": now,                      // time.Time
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}

--- a/tests/engine_time_matching_test.go
+++ b/tests/engine_time_matching_test.go
@@ -1,0 +1,132 @@
+package tests_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atlasgurus/rulestone/condition"
+	"github.com/atlasgurus/rulestone/engine"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMatchEvent_TimeOperandCategories tests that time.Time fields in events trigger rule matches
+func TestMatchEvent_TimeOperandCategories(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	// Rule that references a time field
+	yamlRule := `- metadata:
+    id: 1
+    name: Recent Login Check
+  expression: last_login != null
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("time.Time value triggers match", func(t *testing.T) {
+		event := map[string]interface{}{
+			"last_login": time.Now(),
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("*time.Time pointer triggers match", func(t *testing.T) {
+		now := time.Now()
+		event := map[string]interface{}{
+			"last_login": &now,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("nil *time.Time does not match", func(t *testing.T) {
+		var nilTime *time.Time = nil
+		event := map[string]interface{}{
+			"last_login": nilTime,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("zero time.Time triggers match", func(t *testing.T) {
+		// Zero time is still a valid time value, not null
+		var zeroTime time.Time
+		event := map[string]interface{}{
+			"last_login": zeroTime,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}
+
+// TestMatchEvent_TimeWithOtherTypes tests mixed type events including time.Time
+func TestMatchEvent_TimeWithOtherTypes(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	// Mixed type event
+	yamlRule := `- metadata:
+    id: 1
+    name: Mixed Type Check
+  expression: user_count > 5 && last_login != null && is_active == true
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("mixed types including time.Time", func(t *testing.T) {
+		event := map[string]interface{}{
+			"user_count":  10,
+			"last_login":  time.Now(),
+			"is_active":   true,
+			"device_name": "iPhone 12",
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("mixed types with nil *time.Time", func(t *testing.T) {
+		var nilTime *time.Time = nil
+		event := map[string]interface{}{
+			"user_count": 10,
+			"last_login": nilTime,
+			"is_active":  true,
+		}
+
+		// Should not match because last_login is null
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("mixed types with zero time.Time", func(t *testing.T) {
+		var zeroTime time.Time
+		event := map[string]interface{}{
+			"user_count": 10,
+			"last_login": zeroTime,
+			"is_active":  true,
+		}
+
+		// Should match because zero time != null
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}

--- a/tests/time_integration_test.go
+++ b/tests/time_integration_test.go
@@ -1,0 +1,163 @@
+package tests_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atlasgurus/rulestone/condition"
+	"github.com/atlasgurus/rulestone/engine"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTimeIntegration demonstrates that time.Time support works end-to-end
+// This test verifies that the panic issue is fixed and time values can be processed
+func TestTimeIntegration(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	// Test 1: Simple null check on time field (should not panic)
+	yamlRule1 := `- metadata:
+    id: 1
+    name: Time Field Null Check
+  expression: login_time != null
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule1,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("time.Time value does not panic", func(t *testing.T) {
+		event := map[string]interface{}{
+			"login_time": time.Now(),
+		}
+
+		// This should not panic - that was the main bug
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("*time.Time pointer does not panic", func(t *testing.T) {
+		now := time.Now()
+		event := map[string]interface{}{
+			"login_time": &now,
+		}
+
+		// This should not panic
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("nil *time.Time is treated as null", func(t *testing.T) {
+		var nilTime *time.Time = nil
+		event := map[string]interface{}{
+			"login_time": nilTime,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("zero time.Time is not null", func(t *testing.T) {
+		var zeroTime time.Time
+		event := map[string]interface{}{
+			"login_time": zeroTime,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}
+
+// TestTimeWithMixedTypes verifies time fields work alongside other types
+func TestTimeWithMixedTypes(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	yamlRule := `- metadata:
+    id: 1
+    name: Mixed Types
+  expression: user_count > 5 && login_time != null && is_active == true
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("mixed types including time.Time", func(t *testing.T) {
+		event := map[string]interface{}{
+			"user_count":  10,
+			"login_time":  time.Now(),
+			"is_active":   true,
+			"device_name": "iPhone",
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("mixed types with nil time fails", func(t *testing.T) {
+		var nilTime *time.Time = nil
+		event := map[string]interface{}{
+			"user_count": 10,
+			"login_time": nilTime,
+			"is_active":  true,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.NotContains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}
+
+// TestMultipleTimeFields verifies multiple time fields in the same event
+func TestMultipleTimeFields(t *testing.T) {
+	repo := engine.NewRuleEngineRepo()
+
+	yamlRule := `- metadata:
+    id: 1
+    name: Multiple Time Fields
+  expression: created_at != null && updated_at != null
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("multiple time fields", func(t *testing.T) {
+		now := time.Now()
+		event := map[string]interface{}{
+			"created_at": now.Add(-24 * time.Hour),
+			"updated_at": now,
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+
+	t.Run("mixed time.Time and *time.Time", func(t *testing.T) {
+		now := time.Now()
+		created := now.Add(-24 * time.Hour)
+		event := map[string]interface{}{
+			"created_at": created, // time.Time
+			"updated_at": &now,    // *time.Time
+		}
+
+		matchedIDs := ruleEngine.MatchEvent(event)
+		require.Contains(t, matchedIDs, condition.RuleIdType(0))
+	})
+}

--- a/tests/user_reproduction_test.go
+++ b/tests/user_reproduction_test.go
@@ -1,0 +1,106 @@
+package tests_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atlasgurus/rulestone/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRulestoneTimePanic reproduces the panic when rulestone processes time.Time types
+// This is a minimal unit test without e2e machinery
+func TestRulestoneTimePanic(t *testing.T) {
+	// Create a simple rulestone engine with a basic rule
+	repo := engine.NewRuleEngineRepo()
+
+	// Simple rule: total_accounts_on_device >= 1
+	yamlRule := `- metadata:
+    id: 1
+    name: Test Rule
+  expression: total_accounts_on_device >= 1
+`
+
+	result, err := repo.LoadRulesFromString(yamlRule,
+		engine.WithValidate(true),
+		engine.WithRunTests(false),
+		engine.WithFileFormat("yaml"),
+	)
+	require.NoError(t, err)
+	require.True(t, result.ValidationOK)
+	require.Empty(t, result.Errors)
+
+	// Create engine
+	ruleEngine, err := engine.NewRuleEngine(repo)
+	require.NoError(t, err)
+
+	t.Run("Baseline - Safe types work fine", func(t *testing.T) {
+		event := map[string]interface{}{
+			"total_accounts_on_device": 5,
+			"browser_name":             "Chrome",
+			"is_new_device":            true,
+			"score":                    100.5,
+		}
+
+		// Should not panic
+		matchedIDs := ruleEngine.MatchEvent(event)
+		assert.NotNil(t, matchedIDs)
+		t.Log("✓ Safe types (int, string, bool, float) work fine")
+	})
+
+	t.Run("FIXED - time.Time value no longer causes panic", func(t *testing.T) {
+		now := time.Now()
+		event := map[string]interface{}{
+			"total_accounts_on_device": 5,
+			"device_last_seen":         now, // ← time.Time VALUE
+		}
+
+		// This should NOT panic anymore
+		matchedIDs := ruleEngine.MatchEvent(event)
+		assert.NotNil(t, matchedIDs)
+		t.Log("✓ time.Time value works fine now")
+	})
+
+	t.Run("FIXED - *time.Time pointer no longer causes panic", func(t *testing.T) {
+		now := time.Now()
+		event := map[string]interface{}{
+			"total_accounts_on_device": 5,
+			"device_last_seen":         &now, // ← *time.Time POINTER
+		}
+
+		// This should NOT panic anymore
+		matchedIDs := ruleEngine.MatchEvent(event)
+		assert.NotNil(t, matchedIDs)
+		t.Log("✓ *time.Time pointer works fine now")
+	})
+
+	t.Run("Workaround - Derived float64 field works", func(t *testing.T) {
+		now := time.Now()
+		daysSince := time.Since(now).Hours() / 24.0
+
+		event := map[string]interface{}{
+			"total_accounts_on_device":    5,
+			"days_since_device_last_seen": daysSince, // ← Derived float64 works fine
+		}
+
+		// Should not panic
+		matchedIDs := ruleEngine.MatchEvent(event)
+		assert.NotNil(t, matchedIDs)
+		t.Log("✓ Derived float64 field works fine")
+	})
+
+	t.Run("Edge case - nil pointer does not cause panic", func(t *testing.T) {
+		var nilTime *time.Time = nil
+
+		event := map[string]interface{}{
+			"total_accounts_on_device": 5,
+			"device_last_seen":         nilTime, // ← nil pointer
+		}
+
+		// Should not panic
+		matchedIDs := ruleEngine.MatchEvent(event)
+		assert.NotNil(t, matchedIDs)
+		t.Log("✓ nil pointer is handled correctly")
+	})
+}


### PR DESCRIPTION
## Summary

This PR fixes the panic that occurred when processing events containing `time.Time` or `*time.Time` fields and adds comprehensive time support to the rulestone library.

## Problem

The library would panic when events contained `time.Time` or `*time.Time` fields with the error "Should not get here". This was due to two critical bugs:

1. **Input Bug**: `NewInterfaceOperand()` didn't handle Go's `time.Time` or `*time.Time` types
2. **Output Bug**: `MatchEvent()` switch statement only handled 4 operand types, missing `TimeOperand`, `FloatOperand`, `StringOperand`, and `NullOperand`

## Solution

### Core Fixes

1. **Added time.Time handling to `NewInterfaceOperand()`** (condition/condition.go)
   - `time.Time` values → `TimeOperand`
   - `*time.Time` pointers → `TimeOperand` (or `NullOperand` if nil)

2. **Completed `MatchEvent()` operand handling** (engine/engine_api.go)
   - Added cases for `FloatOperand`, `StringOperand`, `TimeOperand`, `NullOperand`
   - Implements "truthiness" semantics consistently

3. **Fixed `buildObjectMap()` for time.Time structs** (objectmap/object_attribute_map.go)
   - Special handling before reflect.Kind check

4. **Added time-string comparison support** (engine/engine_impl.go)
   - Bidirectional conversion in hash-based lookup optimization
   - Enables `event_time == "2024-01-15T12:00:00Z"` to work

5. **Implemented `now()` built-in function** (engine/engine_impl.go)
   - Returns current time at rule evaluation
   - Enables time arithmetic: `(now() - event_time) < 86400000000000`

## Features

- ✅ Full support for `time.Time` and `*time.Time` values in events
- ✅ Timezone-aware time comparisons using `time.Time.Equal()`
- ✅ Nanosecond precision preserved via `UnixNano()`
- ✅ Time comparisons: `<`, `>`, `==`, `!=`, `<=`, `>=`
- ✅ Time arithmetic with `now()` function
- ✅ String-to-time bidirectional conversion for comparisons
- ✅ `nil *time.Time` treated as `NullOperand`
- ✅ Zero `time.Time` treated as valid time (not null)

## Tests

Added **74+ comprehensive tests** covering:

- **Type conversion** (6 tests): time.Time, *time.Time, nil, zero values, epochs, timezones
- **Time comparisons** (6 tests): <, >, ==, >=, <=, pointers, nanosecond precision
- **Timezone handling** (3 tests): UTC, EST, timezone-aware equality
- **Time arithmetic** (2 tests): now() function, time differences
- **Edge cases** (11 tests): zero time, nil, Unix epoch, far future/past, nanoseconds, leap years, DST
- **Operand conversions** (18 tests): All conversion paths between types
- **Integration scenarios** (10+ tests): Mixed types, multiple time fields, end-to-end
- **User reproduction** (5 tests): Original bug report test cases

### Test Results

```
✅ All 74+ new tests passing
✅ User reproduction test passing (all 5 cases)
✅ All existing tests passing (no regressions)
✅ Full test suite: PASS
```

## Design Decisions

1. **nil `*time.Time` → `NullOperand`**: Consistent with Go's nil semantics
2. **Zero `time.Time` is NOT null**: Zero time is a valid time value (0001-01-01 00:00:00 UTC)
3. **Nanosecond precision**: Uses `UnixNano()` for hashing and comparisons
4. **Timezone-aware**: Uses `time.Time.Equal()` for instant comparisons (not wall clock)
5. **RFC3339Nano format**: Used for time-to-string conversions
6. **String ↔ Time conversion**: Enabled because date strings are unambiguous
7. **Number ↔ Time conversion**: Disabled in constant optimization (creates ambiguity)

## Files Modified

- `condition/condition.go`: Added time.Time type handling
- `engine/engine_api.go`: Fixed MatchEvent operand handling
- `engine/engine_impl.go`: Time-string conversion + now() function
- `objectmap/object_attribute_map.go`: Time.Time struct handling
- `tests/condition_test.go`: Added time type tests

## Files Added

- `TIME_SUPPORT_IMPLEMENTATION_PLAN.md`: Comprehensive implementation plan
- `tests/condition_time_conversion_test.go`: Operand conversion tests
- `tests/engine_time_comparison_test.go`: Time comparison rule tests
- `tests/engine_time_edge_cases_test.go`: Edge case tests
- `tests/engine_time_matching_test.go`: MatchEvent integration tests
- `tests/time_integration_test.go`: End-to-end scenarios
- `tests/user_reproduction_test.go`: Original bug reproduction

## Example Usage

```go
// Events with time fields now work seamlessly
event := map[string]interface{}{
    "user_id": 123,
    "last_login": time.Now(),
    "account_created": time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
}

// Rules can compare times
rule := `
- metadata:
    id: 1
  expression: last_login > "2024-01-01T00:00:00Z"
`

// Time arithmetic works
rule := `
- metadata:
    id: 2
  expression: (now() - last_login) < 86400000000000  # 1 day in nanoseconds
`

matchedRules := ruleEngine.MatchEvent(event)
```

## Breaking Changes

None. This is a pure addition of functionality that previously would panic.

## Migration

No migration needed. Code using workarounds (converting time to float64) will continue to work, but can now use time.Time directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)